### PR TITLE
Upgrade from .NET8 to .NET10

### DIFF
--- a/DynamoSharp.Examples/AscendingAndDescenting/AscendingAndDescenting.csproj
+++ b/DynamoSharp.Examples/AscendingAndDescenting/AscendingAndDescenting.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/CompositeKeysWithHierarchicalData/CompositeKeysWithHierarchicalData.csproj
+++ b/DynamoSharp.Examples/CompositeKeysWithHierarchicalData/CompositeKeysWithHierarchicalData.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/GlobalSecondaryIndex/GlobalSecondaryIndex.csproj
+++ b/DynamoSharp.Examples/GlobalSecondaryIndex/GlobalSecondaryIndex.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/GlobalSecondaryIndexQueryPk/GlobalSecondaryIndexQueryPk.csproj
+++ b/DynamoSharp.Examples/GlobalSecondaryIndexQueryPk/GlobalSecondaryIndexQueryPk.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/GlobalSecondaryIndexQueryPkAndSk/GlobalSecondaryIndexQueryPkAndSk.csproj
+++ b/DynamoSharp.Examples/GlobalSecondaryIndexQueryPkAndSk/GlobalSecondaryIndexQueryPkAndSk.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/ManyToMany/ManyToMany.csproj
+++ b/DynamoSharp.Examples/ManyToMany/ManyToMany.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/ManyToManyQuery/ManyToManyQuery.csproj
+++ b/DynamoSharp.Examples/ManyToManyQuery/ManyToManyQuery.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/ManyToManyWithCustomPrimaryKey/ManyToManyWithCustomPrimaryKey.csproj
+++ b/DynamoSharp.Examples/ManyToManyWithCustomPrimaryKey/ManyToManyWithCustomPrimaryKey.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/ManyToManyWithCustomPrimaryKeyQuery/ManyToManyWithCustomPrimaryKeyQuery.csproj
+++ b/DynamoSharp.Examples/ManyToManyWithCustomPrimaryKeyQuery/ManyToManyWithCustomPrimaryKeyQuery.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/OneToMany/OneToMany.csproj
+++ b/DynamoSharp.Examples/OneToMany/OneToMany.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/OneToManyWithCustomPrimaryKey/OneToManyWithCustomPrimaryKey.csproj
+++ b/DynamoSharp.Examples/OneToManyWithCustomPrimaryKey/OneToManyWithCustomPrimaryKey.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/OneToManyWithCustomPrimaryKeyQueryPk/OneToManyWithCustomPrimaryKeyQueryPk.csproj
+++ b/DynamoSharp.Examples/OneToManyWithCustomPrimaryKeyQueryPk/OneToManyWithCustomPrimaryKeyQueryPk.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/OptimisticLockingSave/OptimisticLockingSave.csproj
+++ b/DynamoSharp.Examples/OptimisticLockingSave/OptimisticLockingSave.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/OptimisticLockingUpdate/OptimisticLockingUpdate.csproj
+++ b/DynamoSharp.Examples/OptimisticLockingUpdate/OptimisticLockingUpdate.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/Pagination/Pagination.csproj
+++ b/DynamoSharp.Examples/Pagination/Pagination.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/PrimaryKeyUsingNestedProperties/PrimaryKeyUsingNestedProperties.csproj
+++ b/DynamoSharp.Examples/PrimaryKeyUsingNestedProperties/PrimaryKeyUsingNestedProperties.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/SimplePrimaryKey/SimplePrimaryKey.csproj
+++ b/DynamoSharp.Examples/SimplePrimaryKey/SimplePrimaryKey.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/SortKeyWithHierarchicalData/SortKeyWithHierarchicalData.csproj
+++ b/DynamoSharp.Examples/SortKeyWithHierarchicalData/SortKeyWithHierarchicalData.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/SortKeyWithHierarchicalDataQuery/SortKeyWithHierarchicalDataQuery.csproj
+++ b/DynamoSharp.Examples/SortKeyWithHierarchicalDataQuery/SortKeyWithHierarchicalDataQuery.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Examples/SparseIndex/SparseIndex.csproj
+++ b/DynamoSharp.Examples/SparseIndex/SparseIndex.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamoSharp.Tests/DynamoSharp.Tests.csproj
+++ b/DynamoSharp.Tests/DynamoSharp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -12,17 +12,17 @@
 
     <ItemGroup>
         <PackageReference Include="Ardalis.SmartEnum" Version="8.2.0" />
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+        <PackageReference Include="coverlet.msbuild" Version="8.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/DynamoSharp/DynamoSharp.csproj
+++ b/DynamoSharp/DynamoSharp.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>0.1.5</Version>
+		<Version>0.2.0</Version>
 		<Authors>Chris Perez</Authors>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>$(AssemblyName)</PackageId>
@@ -18,15 +18,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.509.22" />
-		<PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.400" />
-		<PackageReference Include="EfficientDynamoDb" Version="0.9.18" />
+		<PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.15.2" />
+		<PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.25" />
+		<PackageReference Include="EfficientDynamoDb" Version="0.9.19" />
 		<PackageReference Include="EfficientDynamoDb.Credentials.AWSSDK" Version="0.9.3" />
-		<PackageReference Include="FluentAssertions" Version="8.5.0" />
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+		<PackageReference Include="FluentAssertions" Version="8.9.0" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Changes

- Upgrade all projects to .NET 10
- Upgrade packages to stable versions in `DynamoSharp` project
- Upgrade packages to stable versions in `DynamoSharp.Tests` project
- Upgrade packages to stable versions of all projects in `DynamoSharp.Examples`

---

## ⚠️ Known Issue: `FallbackCredentialsFactory` deprecated in AWSSDK v4

`FallbackCredentialsFactory.GetCredentials()` is marked as obsolete in AWSSDK v4.
The recommended replacement is `DefaultAWSCredentialsIdentityResolver`, introduced in AWSSDK `v4.0.30.0`.
However, this version has **not been published as stable** on NuGet yet — the latest stable available is `v4.0.15.2`, which does not include the fix.

This will be resolved once AWSSDK `v4.0.30.0` (or greater) is published as stable.

> 📎 Reference: https://github.com/aws/aws-sdk-net/issues/3836

---

## Verification

All projects show no outdated packages after the upgrade:
<img width="1138" height="696" alt="DynamoSharp-Upgraded-Packages" src="https://github.com/user-attachments/assets/0d926794-c732-40c8-9c7b-415352b1460c" />
